### PR TITLE
for issue #82 さっくるのタイトルと Mike & Robin の翻訳情報追加

### DIFF
--- a/public/conference/2015/1/session/index.html
+++ b/public/conference/2015/1/session/index.html
@@ -345,7 +345,7 @@
         <div>11:20 - 12:00</div>
       </div>
       <div class="conf2015s-session__title">
-        <h1>はじめてのWeb of Things（仮）</h1>
+        <h1>はじめてのWeb of Things</h1>
       </div>
       <div class="conf2015s-session__tag">
         <div class="conf2015s-session__tagLabel">
@@ -578,6 +578,7 @@
         </ul>
       </div>
       <div class="conf2015s-session__main">
+        <p><strong>※ html5jスタッフによる同時概要通訳Tweetを行います</strong></p>
         <p>Our Web is young—just 25 years old! It has learned to at times "reboot" itself. One of those times is now.</p>
         <p>Some say "Extensible Web" about the current Web reboot — but it's way more exciting than that. You'll learn to be excited you're alive in 2015, and to be part of big changes in the Web.</p>
         <p>【日本語訳】</p>
@@ -617,6 +618,7 @@
         </ul>
       </div>
       <div class="conf2015s-session__main">
+        <p><strong>※ html5jスタッフによる同時概要通訳Tweetを行います</strong></p>
         <p>The magic of the Web is built by Web developers, yet Web developers have not been very involved in the creation of Web technology itself.</p>
         <p>This changes now.</p>
         <p>The "Web Platform Specs" project makes open standard development as easy as open source is. This talk goes into the details of how that works.</p>


### PR DESCRIPTION
セッションページより
- さっくるのタイトルが（仮）がついてたので削除
- Mike & Robinについて、同時概要翻訳tweetを行う旨表記
を修正した