### PR TITLE
古いIE向けのコードを削除

### DIFF
--- a/public/conference/2016/9/access/index.html
+++ b/public/conference/2016/9/access/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>会場・アクセス | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/access/index.html
+++ b/public/conference/2016/9/access/index.html
@@ -136,7 +136,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/assets/style/all.css
+++ b/public/conference/2016/9/assets/style/all.css
@@ -1,20 +1,22 @@
 @charset "UTF-8";
-/*! normalize.css v3.0.1 | MIT License | git.io/normalize */
+/*! normalize.css v4.2.0 | MIT License | github.com/necolas/normalize.css */
 /**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in IE and iOS.
  */
 html {
   font-family: sans-serif;
   /* 1 */
-  -ms-text-size-adjust: 100%;
+  line-height: 1.15;
   /* 2 */
+  -ms-text-size-adjust: 100%;
+  /* 3 */
   -webkit-text-size-adjust: 100%;
-  /* 2 */ }
+  /* 3 */ }
 
 /**
- * Remove default margin.
+ * Remove the margin in all browsers (opinionated).
  */
 body {
   margin: 0; }
@@ -22,9 +24,9 @@ body {
 /* HTML5 display definitions
    ========================================================================== */
 /**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ * 2. Add the correct display in IE.
  */
 article,
 aside,
@@ -33,101 +35,122 @@ figcaption,
 figure,
 footer,
 header,
-hgroup,
 main,
+menu,
 nav,
 section,
 summary {
+  /* 1 */
   display: block; }
 
 /**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ * Add the correct display in IE 9-.
  */
 audio,
 canvas,
 progress,
 video {
-  display: inline-block;
-  /* 1 */
-  vertical-align: baseline;
-  /* 2 */ }
+  display: inline-block; }
 
 /**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
+ * Add the correct display in iOS 4-7.
  */
 audio:not([controls]) {
   display: none;
   height: 0; }
 
 /**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
-[hidden],
-template {
+progress {
+  vertical-align: baseline; }
+
+/**
+ * Add the correct display in IE 10-.
+ * 1. Add the correct display in IE.
+ */
+template,
+[hidden] {
   display: none; }
 
 /* Links
    ========================================================================== */
 /**
- * Remove the gray background color from active links in IE 10.
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
  */
 a {
-  background: transparent; }
+  background-color: transparent;
+  /* 1 */
+  -webkit-text-decoration-skip: objects;
+  /* 2 */ }
 
 /**
- * Improve readability when focused and also mouse hovered in all browsers.
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
  */
 a:active,
 a:hover {
-  outline: 0; }
+  outline-width: 0; }
 
 /* Text-level semantics
    ========================================================================== */
 /**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ * 1. Remove the bottom border in Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
-  border-bottom: 1px dotted; }
+  border-bottom: none;
+  /* 1 */
+  text-decoration: underline;
+  /* 2 */
+  text-decoration: underline dotted;
+  /* 2 */ }
 
 /**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
  */
 b,
 strong {
-  font-weight: bold; }
+  font-weight: inherit; }
 
 /**
- * Address styling not present in Safari and Chrome.
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+  font-weight: bolder; }
+
+/**
+ * Add the correct font style in Android 4.3-.
  */
 dfn {
   font-style: italic; }
 
 /**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
  */
 h1 {
   font-size: 2em;
   margin: 0.67em 0; }
 
 /**
- * Address styling not present in IE 8/9.
+ * Add the correct background and color in IE 9-.
  */
 mark {
-  background: #ff0;
+  background-color: #ff0;
   color: #000; }
 
 /**
- * Address inconsistent and variable font size in all browsers.
+ * Add the correct font size in all browsers.
  */
 small {
   font-size: 80%; }
 
 /**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
  */
 sub,
 sup {
@@ -136,22 +159,22 @@ sup {
   position: relative;
   vertical-align: baseline; }
 
-sup {
-  top: -0.5em; }
-
 sub {
   bottom: -0.25em; }
+
+sup {
+  top: -0.5em; }
 
 /* Embedded content
    ========================================================================== */
 /**
- * Remove border when inside `a` element in IE 8/9/10.
+ * Remove the border on images inside links in IE 10-.
  */
 img {
-  border: 0; }
+  border-style: none; }
 
 /**
- * Correct overflow not hidden in IE 9/10/11.
+ * Hide the overflow in IE.
  */
 svg:not(:root) {
   overflow: hidden; }
@@ -159,160 +182,109 @@ svg:not(:root) {
 /* Grouping content
    ========================================================================== */
 /**
- * Address margin not present in IE 8/9 and Safari.
- */
-figure {
-  margin: 1em 40px; }
-
-/**
- * Address differences between Firefox and other browsers.
- */
-hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0; }
-
-/**
- * Contain overflow in all browsers.
- */
-pre {
-  overflow: auto; }
-
-/**
- * Address odd `em`-unit font size rendering in all browsers.
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
  */
 code,
 kbd,
 pre,
 samp {
   font-family: monospace, monospace;
-  font-size: 1em; }
+  /* 1 */
+  font-size: 1em;
+  /* 2 */ }
+
+/**
+ * Add the correct margin in IE 8.
+ */
+figure {
+  margin: 1em 40px; }
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+  box-sizing: content-box;
+  /* 1 */
+  height: 0;
+  /* 1 */
+  overflow: visible;
+  /* 2 */ }
 
 /* Forms
    ========================================================================== */
 /**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
  */
 button,
 input,
 optgroup,
 select,
 textarea {
-  color: inherit;
-  /* 1 */
   font: inherit;
-  /* 2 */
-  margin: 0;
-  /* 3 */ }
-
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
-button {
-  overflow: visible; }
-
-/**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
- */
-button,
-select {
-  text-transform: none; }
-
-/**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
- */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button;
-  /* 2 */
-  cursor: pointer;
-  /* 3 */ }
-
-/**
- * Re-set default cursor for disabled elements.
- */
-button[disabled],
-html input[disabled] {
-  cursor: default; }
-
-/**
- * Remove inner padding and border in Firefox 4+.
- */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0; }
-
-/**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
-input {
-  line-height: normal; }
-
-/**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
   /* 1 */
-  padding: 0;
+  margin: 0;
   /* 2 */ }
 
 /**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
+ * Restore the font weight unset by the previous rule.
  */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto; }
+optgroup {
+  font-weight: bold; }
 
 /**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
  */
-input[type="search"] {
-  -webkit-appearance: textfield;
+button,
+input {
   /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  /* 2 */
-  box-sizing: content-box; }
+  overflow: visible; }
 
 /**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
  */
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none; }
+button,
+select {
+  /* 1 */
+  text-transform: none; }
 
 /**
- * Define consistent border, margin, and padding.
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */ }
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0; }
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText; }
+
+/**
+ * Change the border, margin, and padding in all browsers (opinionated).
  */
 fieldset {
   border: 1px solid #c0c0c0;
@@ -320,40 +292,82 @@ fieldset {
   padding: 0.35em 0.625em 0.75em; }
 
 /**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
  */
 legend {
-  border: 0;
+  box-sizing: border-box;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  display: table;
+  /* 1 */
+  max-width: 100%;
   /* 1 */
   padding: 0;
-  /* 2 */ }
+  /* 3 */
+  white-space: normal;
+  /* 1 */ }
 
 /**
- * Remove default vertical scrollbar in IE 8/9/10/11.
+ * Remove the default vertical scrollbar in IE.
  */
 textarea {
   overflow: auto; }
 
 /**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
  */
-optgroup {
-  font-weight: bold; }
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */ }
 
-/* Tables
-   ========================================================================== */
 /**
- * Remove most spacing between table cells.
+ * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-table {
-  border-collapse: collapse;
-  border-spacing: 0; }
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
 
-td,
-th {
-  padding: 0; }
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */ }
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ */
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54; }
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */ }
 
 .conf2016s-icon-bars, .conf2016s-icon-clione, .conf2016s-icon-webgl, .conf2016s-icon-down, .conf2016s-icon-up, .conf2016s-icon-right, .conf2016s-icon-left, .conf2016s-icon-right2, .conf2016s-icon-left2, .conf2016s-icon-down2, .conf2016s-icon-up2 {
   font-family: 'icon';
@@ -374,10 +388,10 @@ th {
    ========================================================================== */
 @font-face {
   font-family: 'icon';
-  src: url("../fonts/icon.eot");
-  src: url("../fonts/icon.eot#iefix") format("embedded-opentype"), url("../fonts/icon.woff") format("woff"), url("../fonts/icon.ttf") format("truetype");
+  src: url("../fonts/icon.woff") format("woff");
   font-weight: normal;
   font-style: normal; }
+
 .conf2016s-icon-bars:before {
   content: ""; }
 
@@ -419,9 +433,10 @@ th {
 /* Basic comment */
 @font-face {
   font-family: 'zero-width';
-  src: url("//:") format("No-IE-404"), url("../fonts/zero-width.woff") format("woff"), url("../fonts/zero-width.svg") format("svg"), url("../fonts/zero-width.otf") format("opentype"), url("../fonts/zero-width.ttf") format("truetype");
+  src: url("../fonts/zero-width.woff") format("woff");
   font-weight: normal;
   font-style: normal; }
+
 /* ==========================================================================
    for styleguide
    ========================================================================== */
@@ -481,9 +496,9 @@ th {
 @media screen and (max-width: 639px) {
   .conf2016s--disableLeargeScreen {
     display: block !important; }
-
   .conf2016s--disableSmallScreen {
     display: none  !important; } }
+
 /* ==========================================================================
    general style
    ========================================================================== */
@@ -557,36 +572,33 @@ a:hover, a:active {
   .conf2016s-pageHeader__logo img {
     width: 75px;
     height: auto; }
-
   .conf2016s-pageHeader__title img {
     width: 211.5px;
     height: auto; } }
+
 @media screen and (max-width: 639px) {
   .conf2016s-pageHeader__inner {
     display: block;
     text-align: center; }
-
   .conf2016s-pageHeader__logo,
   .conf2016s-pageHeader__title {
     display: inline-block;
     vertical-align: middle;
     width: auto; }
-
   .conf2016s-pageHeader__logo img {
     width: 50px; }
-
   .conf2016s-pageHeader__title {
     top: 8px;
     left: 0px; }
     .conf2016s-pageHeader__title img {
       width: 141px; }
-
   .conf2016s-info {
     font-size: 0.875rem;
     line-height: 1.4;
     text-align: center;
     display: block;
     margin-top: 10px; } }
+
 /* ==========================================================================
    .conf2016s-pageNav
    ========================================================================== */
@@ -629,12 +641,12 @@ nav.conf2016s-pageNav {
 @media screen and (max-width: 767px) {
   .conf2016s-pageNav__inner ul {
     font-size: 0.75rem; } }
+
 @media screen and (max-width: 639px) {
   nav.conf2016s-pageNav {
     border-top: none;
     border-bottom: none;
     background: none; }
-
   .conf2016s-pageNav__inner {
     padding: 0; }
     .conf2016s-pageNav__inner ul {
@@ -655,7 +667,6 @@ nav.conf2016s-pageNav {
       color: #1b354c;
       text-decoration: none;
       padding: 10px; }
-
   .conf2016s-pageNav__opener {
     line-height: 1;
     cursor: pointer;
@@ -681,6 +692,7 @@ nav.conf2016s-pageNav {
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       font-size: 24px; } }
+
 /* ==========================================================================
    .conf2016s-hero
    ========================================================================== */
@@ -715,7 +727,6 @@ nav.conf2016s-pageNav {
 @media screen and (max-width: 639px) {
   .conf2016s-hero {
     background: none; }
-
   .conf2016s-hero__info {
     color: #000;
     font-size: 0.875rem;
@@ -724,6 +735,7 @@ nav.conf2016s-pageNav {
     margin-top: 4px;
     position: static;
     background: none; } }
+
 /* ==========================================================================
    .conf2016s-container
    ========================================================================== */
@@ -853,6 +865,7 @@ nav.conf2016s-pageNav {
     .conf2016s-buttonContainer li {
       display: block;
       width: 100%; } }
+
 /* ==========================================================================
    .conf2016s-table
    ========================================================================== */
@@ -867,6 +880,7 @@ nav.conf2016s-pageNav {
   .conf2016s-table th, .conf2016s-table td {
     display: block;
     padding: .2em 0; } }
+
 /* ==========================================================================
    .conf2016s-timetable
    ========================================================================== */
@@ -920,7 +934,7 @@ nav.conf2016s-pageNav {
   font-size: smaller; }
   .conf2016s-timetable-speaker li {
     display: inline-block;
-    margin-right:  0.5em; }
+    margin-right: 0.5em; }
 
 .conf2016s-timetable-speaker-image {
   margin-right: 5px;
@@ -1020,10 +1034,12 @@ nav.conf2016s-pageNav {
 @media screen and (max-width: 767px) {
   .conf2016s-item4 {
     width: 49.999%; } }
+
 @media screen and (max-width: 639px) {
   .conf2016s-item4 {
     display: block;
     width: auto; } }
+
 /* ==========================================================================
    .conf2016s-pageFooter
    ========================================================================== */
@@ -1074,6 +1090,7 @@ footer.conf2016s-pageFooter {
   margin-top: 16px; }
   .conf2016s-eventSummary dt:first-child {
     margin-top: 0; }
+
 .conf2016s-eventSummary dd {
   margin-left: 0;
   font-size: 0.875rem; }
@@ -1136,6 +1153,7 @@ footer.conf2016s-pageFooter {
   margin: 0; }
   .conf2016s-session__tag ul:before {
     content: ' '; }
+
 .conf2016s-session__tag li {
   color: #757575;
   font-size: 12px;
@@ -1242,9 +1260,9 @@ header.conf2016s-sessionGroup__header h1 {
     border: 1px solid #ddd;
     padding: 14px;
     margin: 20px 0 60px; }
-
   header.conf2016s-sessionGroup__header {
     margin-left: 0; } }
+
 /* ==========================================================================
    .conf2016s-speaker
    ========================================================================== */
@@ -1296,27 +1314,23 @@ header.conf2016s-sessionGroup__header h1 {
 @media screen and (max-width: 767px) {
   .conf2016s-speaker {
     width: auto; }
-
   .conf2016s-speaker__image {
     width: 30%; }
     .conf2016s-speaker__image img {
       min-width: 150px; }
-
   .conf2016s-speaker__text {
     width: 70%; }
     .conf2016s-speaker__text:first-child {
       padding-left: 30%; }
-
   .conf2016s-speaker__name {
     font-size: 20px; }
-
   .conf2016s-speaker__bio {
     margin-top: 14px; } }
+
 @media screen and (max-width: 639px) {
   .conf2016s-speaker {
     display: block;
     margin: 30px 0; }
-
   .conf2016s-speaker__image {
     text-align: center;
     display: block;
@@ -1325,51 +1339,48 @@ header.conf2016s-sessionGroup__header h1 {
     .conf2016s-speaker__image img {
       display: inline-block;
       width: auto; }
-
   .conf2016s-speaker__text {
     display: block;
     width: auto;
     padding-top: 0; }
     .conf2016s-speaker__text:first-child {
       padding-left: 0; }
-
   .conf2016s-speaker__name {
     text-align: center; }
-
   .conf2016s-speaker__affil {
     text-align: center; }
-
   .conf2016s-speaker__bio {
     margin-top: 16px; }
     .conf2016s-speaker__bio p {
       margin: 8px 0; }
-
   .conf2016s-speaker__h {
     margin: 10px 0;
     font-weight: bold; } }
+
 /* 画像・地図のスマホ用調整  */
 @media screen and (max-width: 767px) {
   .image {
     text-align: center; }
-
   .image img {
     max-width: 200px;
     width: 100%;
     height: auto; } }
+
 @media screen and (max-width: 639px) {
   .image {
     text-align: center; }
-
   .image img {
     max-width: 200px;
     width: 100%;
     height: auto; } }
+
 /* ==========================================================================
    .conf2016s-access
    ========================================================================== */
 /* アクセス路線の表示調整  */
 .access_root_list dd {
   margin-left: 0; }
+
 .access_root_list ul {
   padding-left: 1.7em; }
   .access_root_list ul > li {
@@ -1386,30 +1397,26 @@ header.conf2016s-sessionGroup__header h1 {
   .google-map {
     width: 100%;
     height: 300px; }
-
   .google-map iframe {
     max-width: 767px;
     width: 100%;
     height: 80%; }
-
   .access_photo img {
     max-width: 640px;
     width: 100%;
     height: auto;
     text-align: center; } }
+
 @media screen and (max-width: 639px) {
   .google-map {
     width: 100%;
     height: 200px; }
-
   .google-map iframe {
     width: 100%;
     height: 100%;
     text-align: center; }
-
   .access_photos {
     width: 100%; }
-
   .access_photo img {
     width: 100%;
     height: auto;

--- a/public/conference/2016/9/faq/index.html
+++ b/public/conference/2016/9/faq/index.html
@@ -111,7 +111,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/faq/index.html
+++ b/public/conference/2016/9/faq/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>よくある質問 | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/guide/index.html
+++ b/public/conference/2016/9/guide/index.html
@@ -115,7 +115,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/guide/index.html
+++ b/public/conference/2016/9/guide/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>当日の流れ | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/index.html
+++ b/public/conference/2016/9/index.html
@@ -326,7 +326,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="./assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/index.html
+++ b/public/conference/2016/9/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header>

--- a/public/conference/2016/9/session/index.html
+++ b/public/conference/2016/9/session/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>セッション情報 | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/session/index.html
+++ b/public/conference/2016/9/session/index.html
@@ -1832,7 +1832,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/speaker/index.html
+++ b/public/conference/2016/9/speaker/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>スピーカー情報 | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/speaker/index.html
+++ b/public/conference/2016/9/speaker/index.html
@@ -580,7 +580,7 @@ IPv6普及高度化推進協議会理事</p>
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/public/conference/2016/9/src/style/_basic.scss
+++ b/public/conference/2016/9/src/style/_basic.scss
@@ -11,11 +11,7 @@
 
 @font-face {
   font-family: 'zero-width';
-  src: url('//:') format("No-IE-404"),
-       url('../fonts/zero-width.woff') format('woff'),
-       url('../fonts/zero-width.svg') format('svg'),
-       url('../fonts/zero-width.otf') format('opentype'),
-       url('../fonts/zero-width.ttf') format('truetype');
+  src: url('../fonts/zero-width.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/public/conference/2016/9/src/style/_icon.scss
+++ b/public/conference/2016/9/src/style/_icon.scss
@@ -4,10 +4,7 @@
    ========================================================================== */
 @font-face {
   font-family: 'icon';
-  src:url('../fonts/icon.eot');
-  src:url('../fonts/icon.eot#iefix') format('embedded-opentype'),
-      url('../fonts/icon.woff') format('woff'),
-      url('../fonts/icon.ttf') format('truetype');
+  src: url('../fonts/icon.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/public/conference/2016/9/src/style/_normalize.scss
+++ b/public/conference/2016/9/src/style/_normalize.scss
@@ -1,19 +1,20 @@
-/*! normalize.css v3.0.1 | MIT License | git.io/normalize */
+/*! normalize.css v4.2.0 | MIT License | github.com/necolas/normalize.css */
 
 /**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in IE and iOS.
  */
 
 html {
   font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  line-height: 1.15; /* 2 */
+  -ms-text-size-adjust: 100%; /* 3 */
+  -webkit-text-size-adjust: 100%; /* 3 */
 }
 
 /**
- * Remove default margin.
+ * Remove the margin in all browsers (opinionated).
  */
 
 body {
@@ -24,42 +25,39 @@ body {
    ========================================================================== */
 
 /**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ * 2. Add the correct display in IE.
  */
 
 article,
 aside,
-details,
+details, /* 1 */
 figcaption,
 figure,
 footer,
 header,
-hgroup,
-main,
+main, /* 2 */
+menu,
 nav,
 section,
-summary {
+summary { /* 1 */
   display: block;
 }
 
 /**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ * Add the correct display in IE 9-.
  */
 
 audio,
 canvas,
 progress,
 video {
-  display: inline-block; /* 1 */
-  vertical-align: baseline; /* 2 */
+  display: inline-block;
 }
 
 /**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
+ * Add the correct display in iOS 4-7.
  */
 
 audio:not([controls]) {
@@ -68,12 +66,20 @@ audio:not([controls]) {
 }
 
 /**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 
-[hidden],
-template {
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Add the correct display in IE 10-.
+ * 1. Add the correct display in IE.
+ */
+
+template, /* 1 */
+[hidden] {
   display: none;
 }
 
@@ -81,44 +87,59 @@ template {
    ========================================================================== */
 
 /**
- * Remove the gray background color from active links in IE 10.
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
  */
 
 a {
-  background: transparent;
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
 }
 
 /**
- * Improve readability when focused and also mouse hovered in all browsers.
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
  */
 
 a:active,
 a:hover {
-  outline: 0;
+  outline-width: 0;
 }
 
 /* Text-level semantics
    ========================================================================== */
 
 /**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ * 1. Remove the bottom border in Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 
 abbr[title] {
-  border-bottom: 1px dotted;
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 
 /**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
  */
 
 b,
 strong {
-  font-weight: bold;
+  font-weight: inherit;
 }
 
 /**
- * Address styling not present in Safari and Chrome.
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * Add the correct font style in Android 4.3-.
  */
 
 dfn {
@@ -126,8 +147,8 @@ dfn {
 }
 
 /**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
  */
 
 h1 {
@@ -136,16 +157,16 @@ h1 {
 }
 
 /**
- * Address styling not present in IE 8/9.
+ * Add the correct background and color in IE 9-.
  */
 
 mark {
-  background: #ff0;
+  background-color: #ff0;
   color: #000;
 }
 
 /**
- * Address inconsistent and variable font size in all browsers.
+ * Add the correct font size in all browsers.
  */
 
 small {
@@ -153,7 +174,8 @@ small {
 }
 
 /**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
  */
 
 sub,
@@ -164,27 +186,27 @@ sup {
   vertical-align: baseline;
 }
 
-sup {
-  top: -0.5em;
-}
-
 sub {
   bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
 }
 
 /* Embedded content
    ========================================================================== */
 
 /**
- * Remove border when inside `a` element in IE 8/9/10.
+ * Remove the border on images inside links in IE 10-.
  */
 
 img {
-  border: 0;
+  border-style: none;
 }
 
 /**
- * Correct overflow not hidden in IE 9/10/11.
+ * Hide the overflow in IE.
  */
 
 svg:not(:root) {
@@ -195,7 +217,20 @@ svg:not(:root) {
    ========================================================================== */
 
 /**
- * Address margin not present in IE 8/9 and Safari.
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct margin in IE 8.
  */
 
 figure {
@@ -203,48 +238,22 @@ figure {
 }
 
 /**
- * Address differences between Firefox and other browsers.
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
  */
 
 hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0;
-}
-
-/**
- * Contain overflow in all browsers.
- */
-
-pre {
-  overflow: auto;
-}
-
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /* Forms
    ========================================================================== */
 
 /**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
-
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
  */
 
 button,
@@ -252,126 +261,76 @@ input,
 optgroup,
 select,
 textarea {
-  color: inherit; /* 1 */
-  font: inherit; /* 2 */
-  margin: 0; /* 3 */
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ * Restore the font weight unset by the previous rule.
  */
 
-button {
+optgroup {
+  font-weight: bold;
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
   overflow: visible;
 }
 
 /**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
  */
 
 button,
-select {
+select { /* 1 */
   text-transform: none;
 }
 
 /**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
  */
 
 button,
-html input[type="button"], /* 1 */
-input[type="reset"],
-input[type="submit"] {
+html [type="button"], /* 1 */
+[type="reset"],
+[type="submit"] {
   -webkit-appearance: button; /* 2 */
-  cursor: pointer; /* 3 */
 }
 
 /**
- * Re-set default cursor for disabled elements.
- */
-
-button[disabled],
-html input[disabled] {
-  cursor: default;
-}
-
-/**
- * Remove inner padding and border in Firefox 4+.
+ * Remove the inner border and padding in Firefox.
  */
 
 button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
   padding: 0;
 }
 
 /**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
+ * Restore the focus styles unset by the previous rule.
  */
 
-input {
-  line-height: normal;
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
 }
 
 /**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
-}
-
-/**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
- */
-
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-
-/**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
- */
-
-input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box; /* 2 */
-  box-sizing: content-box;
-}
-
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-/**
- * Define consistent border, margin, and padding.
+ * Change the border, margin, and padding in all browsers (opinionated).
  */
 
 fieldset {
@@ -381,17 +340,23 @@ fieldset {
 }
 
 /**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
  */
 
 legend {
-  border: 0; /* 1 */
-  padding: 0; /* 2 */
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
 }
 
 /**
- * Remove default vertical scrollbar in IE 8/9/10/11.
+ * Remove the default vertical scrollbar in IE.
  */
 
 textarea {
@@ -399,27 +364,59 @@ textarea {
 }
 
 /**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
  */
 
-optgroup {
-  font-weight: bold;
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
-
-/* Tables
-   ========================================================================== */
 
 /**
- * Remove most spacing between table cells.
+ * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
 }
 
-td,
-th {
-  padding: 0;
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }

--- a/public/conference/2016/9/volunteer/index.html
+++ b/public/conference/2016/9/volunteer/index.html
@@ -2,7 +2,6 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ボランティアスタッフ募集 | HTML5 Conference</title>
     <meta name="description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
@@ -12,9 +11,6 @@
     <meta property="og:image" content="http://events.html5j.org/conference/2016/9/assets/img/ogp.jpg">
     <meta property="og:description" content="HTML5 Conference - 2016年9月3日（土）東京電機大学 千住キャンパスにて開催。">
     <link rel="stylesheet" href="../assets/style/all.css">
-    <!--[if lt IE 9]>
-        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header class="conf2016s-pageHeader">

--- a/public/conference/2016/9/volunteer/index.html
+++ b/public/conference/2016/9/volunteer/index.html
@@ -130,7 +130,7 @@
       </div>
     </footer><!-- /.conf2016s-pageFooter -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/script/page-nav.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Webサイト公開からのアクセスを見ると、IE11がほとんど（IE8-10は1件2件）なので、古いIE向けのコード削除しちゃおうかと。